### PR TITLE
Try to recover from BUS-OFF

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,7 @@ lib_deps =
 	ttlappalainen/NMEA2000-library
 	ttlappalainen/NMEA2000_esp32
 	Adafruit SSD1306
+	pfeerick/elapsedMillis
 
 [espressif32_base]
 platform = espressif32


### PR DESCRIPTION
Instead of simply resetting the device when a BUS-OFF is detected, try to actively recover and continue operation.

Nevertheless, if the N2K network isn't connnected at startup, the recovery won't work. A 30 second timeout and reboot is still enabled for such situations.